### PR TITLE
Add Pporderlines2 GraphQL support

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -15,6 +15,9 @@ import { LocationModule } from './location/location.module';
 import { MeResolver } from './auth/me.resolver';
 import { AuthModule } from './auth/auth.module';
 import { CoilColorModule } from './color/coil.color.module';
+import { PanelspeedsModule } from './panelspeeds/panelspeeds.module';
+import { PpackagesModule } from './ppackages/ppackages.module';
+import { Pporderlines2Module } from './pporderlines2/pporderlines2.module';
 @Module({
   imports: [
     RecipesModule,
@@ -24,7 +27,10 @@ import { CoilColorModule } from './color/coil.color.module';
      CoilColorModule,
      UsersLocationAccessModule,
      LocationModule,
-     AuthModule,
+    PanelspeedsModule,
+    PpackagesModule,
+    Pporderlines2Module,
+    AuthModule,
     GraphQLModule.forRoot<ApolloDriverConfig>({
       driver: ApolloDriver,
       autoSchemaFile: 'schema.gql',

--- a/src/entities/entities/PPackages.ts
+++ b/src/entities/entities/PPackages.ts
@@ -1,26 +1,35 @@
-import { Column, Entity, PrimaryGeneratedColumn } from "typeorm";
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { ObjectType, Field, Int, Float } from '@nestjs/graphql';
 
-@Entity("PPackages", { schema: "dbo" })
+@ObjectType()
+@Entity('PPackages', { schema: 'dbo' })
 export class PPackages {
-  @PrimaryGeneratedColumn({ type: "int", name: "id" })
+  @Field(() => Int)
+  @PrimaryGeneratedColumn({ type: 'int', name: 'id' })
   id: number;
 
-  @Column("nvarchar", { name: "packno", nullable: true, length: 50 })
+  @Field({ nullable: true })
+  @Column('nvarchar', { name: 'packno', nullable: true, length: 50 })
   packno: string | null;
 
-  @Column("int", { name: "iteid", nullable: true })
+  @Field(() => Int, { nullable: true })
+  @Column('int', { name: 'iteid', nullable: true })
   iteid: number | null;
 
-  @Column("nvarchar", { name: "itename", nullable: true, length: 50 })
+  @Field({ nullable: true })
+  @Column('nvarchar', { name: 'itename', nullable: true, length: 50 })
   itename: string | null;
 
-  @Column("nvarchar", { name: "description", nullable: true, length: 250 })
+  @Field({ nullable: true })
+  @Column('nvarchar', { name: 'description', nullable: true, length: 250 })
   description: string | null;
 
-  @Column("int", { name: "pcs", nullable: true })
+  @Field(() => Int, { nullable: true })
+  @Column('int', { name: 'pcs', nullable: true })
   pcs: number | null;
 
-  @Column("decimal", {
+  @Field(() => Float, { nullable: true })
+  @Column('decimal', {
     name: "quantity",
     nullable: true,
     precision: 8,
@@ -28,25 +37,32 @@ export class PPackages {
   })
   quantity: number | null;
 
-  @Column("nvarchar", { name: "tradecode", nullable: true, length: 50 })
+  @Field({ nullable: true })
+  @Column('nvarchar', { name: 'tradecode', nullable: true, length: 50 })
   tradecode: string | null;
 
-  @Column("date", { name: "create_dt", nullable: true })
+  @Field({ nullable: true })
+  @Column('date', { name: 'create_dt', nullable: true })
   createDt: Date | null;
 
-  @Column("date", { name: "despatch_dt", nullable: true })
+  @Field({ nullable: true })
+  @Column('date', { name: 'despatch_dt', nullable: true })
   despatchDt: Date | null;
 
-  @Column("int", { name: "status", nullable: true })
+  @Field(() => Int, { nullable: true })
+  @Column('int', { name: 'status', nullable: true })
   status: number | null;
 
-  @Column("int", { name: "loc", nullable: true })
+  @Field(() => Int, { nullable: true })
+  @Column('int', { name: 'loc', nullable: true })
   loc: number | null;
 
-  @Column("datetime", { name: "up_date", nullable: true })
+  @Field({ nullable: true })
+  @Column('datetime', { name: 'up_date', nullable: true })
   upDate: Date | null;
 
-  @Column("nvarchar", {
+  @Field({ nullable: true })
+  @Column('nvarchar', {
     name: "Classification",
     nullable: true,
     length: 5,
@@ -54,34 +70,44 @@ export class PPackages {
   })
   classification: string | null;
 
-  @Column("nchar", { name: "comment", nullable: true, length: 250 })
+  @Field({ nullable: true })
+  @Column('nchar', { name: 'comment', nullable: true, length: 250 })
   comment: string | null;
 
-  @Column("int", { name: "importNo", nullable: true })
+  @Field(() => Int, { nullable: true })
+  @Column('int', { name: 'importNo', nullable: true })
   importNo: number | null;
 
-  @Column("nvarchar", { name: "panelThickness", nullable: true, length: 10 })
+  @Field({ nullable: true })
+  @Column('nvarchar', { name: 'panelThickness', nullable: true, length: 10 })
   panelThickness: string | null;
 
-  @Column("nvarchar", { name: "cin", nullable: true, length: 100 })
+  @Field({ nullable: true })
+  @Column('nvarchar', { name: 'cin', nullable: true, length: 100 })
   cin: string | null;
 
-  @Column("nvarchar", { name: "cout", nullable: true, length: 100 })
+  @Field({ nullable: true })
+  @Column('nvarchar', { name: 'cout', nullable: true, length: 100 })
   cout: string | null;
 
-  @Column("nvarchar", { name: "thickin", nullable: true, length: 50 })
+  @Field({ nullable: true })
+  @Column('nvarchar', { name: 'thickin', nullable: true, length: 50 })
   thickin: string | null;
 
-  @Column("nvarchar", { name: "thickout", nullable: true, length: 50 })
+  @Field({ nullable: true })
+  @Column('nvarchar', { name: 'thickout', nullable: true, length: 50 })
   thickout: string | null;
 
-  @Column("nvarchar", { name: "moldin", nullable: true, length: 50 })
+  @Field({ nullable: true })
+  @Column('nvarchar', { name: 'moldin', nullable: true, length: 50 })
   moldin: string | null;
 
-  @Column("nvarchar", { name: "moldout", nullable: true, length: 50 })
+  @Field({ nullable: true })
+  @Column('nvarchar', { name: 'moldout', nullable: true, length: 50 })
   moldout: string | null;
 
-  @Column("decimal", {
+  @Field(() => Float, { nullable: true })
+  @Column('decimal', {
     name: "panelWeightPerMeter",
     nullable: true,
     precision: 6,
@@ -89,9 +115,14 @@ export class PPackages {
   })
   panelWeightPerMeter: number | null;
 
-  @Column("nvarchar", { name: "widthin", nullable: true, length: 50 })
+  @Field({ nullable: true })
+  @Column('nvarchar', { name: 'widthin', nullable: true, length: 50 })
   widthin: string | null;
 
-  @Column("nvarchar", { name: "widthout", nullable: true, length: 50 })
+  @Field({ nullable: true })
+  @Column('nvarchar', { name: 'widthout', nullable: true, length: 50 })
   widthout: string | null;
+
+  @Field(() => Float, { nullable: true })
+  total?: number;
 }

--- a/src/entities/entities/PanelSpeeds.ts
+++ b/src/entities/entities/PanelSpeeds.ts
@@ -1,0 +1,18 @@
+import { Column, Entity } from 'typeorm';
+import { ObjectType, Field, Float } from '@nestjs/graphql';
+
+@ObjectType()
+@Entity('PANELSPEEDS', { schema: 'dbo' })
+export class PanelSpeeds {
+  @Field()
+  @Column('nvarchar', { primary: true, name: 'code', length: 50 })
+  code: string;
+
+  @Field({ nullable: true })
+  @Column('nchar', { name: 'thickness', nullable: true, length: 10 })
+  thickness: string | null;
+
+  @Field(() => Float, { nullable: true })
+  @Column('decimal', { name: 'speed', nullable: true, precision: 18, scale: 1 })
+  speed: number | null;
+}

--- a/src/entities/entities/Pporderlines2.ts
+++ b/src/entities/entities/Pporderlines2.ts
@@ -1,32 +1,46 @@
-import { Column, Entity, Index, PrimaryGeneratedColumn } from "typeorm";
+import { Column, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+import { ObjectType, Field, Int, Float } from '@nestjs/graphql';
 
-@Index("PK_PPORDERLINES2", ["id"], { unique: true })
-@Entity("PPORDERLINES2", { schema: "dbo" })
+@ObjectType()
+@Index('PK_PPORDERLINES2', ['id'], { unique: true })
+@Entity('PPORDERLINES2', { schema: 'dbo' })
 export class Pporderlines2 {
-  @PrimaryGeneratedColumn({ type: "int", name: "id" })
+  @Field(() => Int)
+  @PrimaryGeneratedColumn({ type: 'int', name: 'id' })
   id: number;
 
-  @Column("nvarchar", { name: "PPORDERNO", nullable: true, length: 30 })
+  @Field({ nullable: true })
+  @Column('nvarchar', { name: 'PPORDERNO', nullable: true, length: 30 })
   pporderno: string | null;
 
-  @Column("nvarchar", { name: "CUSTPORDERNO", nullable: true, length: 30 })
+  @Field({ nullable: true })
+  @Column('nvarchar', { name: 'CUSTPORDERNO', nullable: true, length: 30 })
   custporderno: string | null;
 
-  @Column("smalldatetime", { name: "prodDate", nullable: true })
+  @Field({ nullable: true })
+  @Column('smalldatetime', { name: 'prodDate', nullable: true })
   prodDate: Date | null;
 
-  @Column("smalldatetime", { name: "up_date", nullable: true })
+  @Field({ nullable: true })
+  @Column('smalldatetime', { name: 'up_date', nullable: true })
   upDate: Date | null;
 
-  @Column("int", { name: "status", nullable: true })
+  @Field(() => Int, { nullable: true })
+  @Column('int', { name: 'status', nullable: true })
   status: number | null;
 
-  @Column("int", { name: "isCanceled", nullable: true, default: () => "(0)" })
+  @Field(() => Int, { nullable: true })
+  @Column('int', { name: 'isCanceled', nullable: true, default: () => '(0)' })
   isCanceled: number | null;
 
-  @Column("nvarchar", { name: "PANELCODE", nullable: true, length: 150 })
+  @Field({ nullable: true })
+  @Column('nvarchar', { name: 'PANELCODE', nullable: true, length: 150 })
   panelcode: string | null;
 
-  @Column("nvarchar", { name: "tradecode", nullable: true, length: 30 })
+  @Field({ nullable: true })
+  @Column('nvarchar', { name: 'tradecode', nullable: true, length: 30 })
   tradecode: string | null;
+
+  @Field(() => Float, { nullable: true })
+  packagesTotal?: number | null;
 }

--- a/src/panelspeeds/panelspeeds.module.ts
+++ b/src/panelspeeds/panelspeeds.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { PanelSpeeds } from '../entities/entities/PanelSpeeds';
+import { PanelspeedsService } from './panelspeeds.service';
+import { PanelspeedsResolver } from './panelspeeds.resolver';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([PanelSpeeds])],
+  providers: [PanelspeedsService, PanelspeedsResolver],
+})
+export class PanelspeedsModule {}

--- a/src/panelspeeds/panelspeeds.resolver.ts
+++ b/src/panelspeeds/panelspeeds.resolver.ts
@@ -1,0 +1,20 @@
+import { Resolver, Query, Args } from '@nestjs/graphql';
+import { PanelspeedsService } from './panelspeeds.service';
+import { PanelSpeeds } from '../entities/entities/PanelSpeeds';
+
+@Resolver(() => PanelSpeeds)
+export class PanelspeedsResolver {
+  constructor(private readonly panelspeedsService: PanelspeedsService) {}
+
+  @Query(() => [PanelSpeeds])
+  async panelSpeeds(): Promise<PanelSpeeds[]> {
+    return this.panelspeedsService.findAll();
+  }
+
+  @Query(() => PanelSpeeds, { nullable: true })
+  async panelSpeed(
+    @Args('code', { type: () => String }) code: string,
+  ): Promise<PanelSpeeds | null> {
+    return this.panelspeedsService.findOne(code);
+  }
+}

--- a/src/panelspeeds/panelspeeds.service.ts
+++ b/src/panelspeeds/panelspeeds.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { PanelSpeeds } from '../entities/entities/PanelSpeeds';
+
+@Injectable()
+export class PanelspeedsService {
+  constructor(
+    @InjectRepository(PanelSpeeds)
+    private readonly panelspeedsRepository: Repository<PanelSpeeds>,
+  ) {}
+
+  findAll(): Promise<PanelSpeeds[]> {
+    return this.panelspeedsRepository.find();
+  }
+
+  findOne(code: string): Promise<PanelSpeeds | null> {
+    return this.panelspeedsRepository.findOne({ where: { code } });
+  }
+}

--- a/src/ppackages/dto/package-speed-result.type.ts
+++ b/src/ppackages/dto/package-speed-result.type.ts
@@ -1,0 +1,13 @@
+import { ObjectType, Field, Float } from '@nestjs/graphql';
+
+@ObjectType()
+export class PackageSpeedResult {
+  @Field()
+  description: string;
+
+  @Field()
+  code: string;
+
+  @Field(() => Float)
+  total: number;
+}

--- a/src/ppackages/ppackages.module.ts
+++ b/src/ppackages/ppackages.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { PPackages } from '../entities/entities/PPackages';
+import { PanelSpeeds } from '../entities/entities/PanelSpeeds';
+import { PpackagesService } from './ppackages.service';
+import { PpackagesResolver } from './ppackages.resolver';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([PPackages, PanelSpeeds])],
+  providers: [PpackagesService, PpackagesResolver],
+})
+export class PpackagesModule {}

--- a/src/ppackages/ppackages.resolver.ts
+++ b/src/ppackages/ppackages.resolver.ts
@@ -1,0 +1,24 @@
+import { Resolver, Query, Args, Int } from '@nestjs/graphql';
+import { PpackagesService } from './ppackages.service';
+import { PPackages } from '../entities/entities/PPackages';
+import { PackageSpeedResult } from './dto/package-speed-result.type';
+
+@Resolver(() => PPackages)
+export class PpackagesResolver {
+  constructor(private readonly ppackagesService: PpackagesService) {}
+
+  @Query(() => [PPackages])
+  async ppackages(): Promise<PPackages[]> {
+    return this.ppackagesService.findAll();
+  }
+
+  @Query(() => PPackages, { nullable: true })
+  async ppackage(@Args('id', { type: () => Int }) id: number): Promise<PPackages | null> {
+    return this.ppackagesService.findOne(id);
+  }
+
+  @Query(() => [PackageSpeedResult])
+  async packageProductionTimes(): Promise<PackageSpeedResult[]> {
+    return this.ppackagesService.calculateQuantitySpeed();
+  }
+}

--- a/src/ppackages/ppackages.service.ts
+++ b/src/ppackages/ppackages.service.ts
@@ -1,0 +1,61 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { PPackages } from '../entities/entities/PPackages';
+import { PanelSpeeds } from '../entities/entities/PanelSpeeds';
+
+@Injectable()
+export class PpackagesService {
+  constructor(
+    @InjectRepository(PPackages)
+    private readonly ppackagesRepository: Repository<PPackages>,
+    @InjectRepository(PanelSpeeds)
+    private readonly panelSpeedsRepository: Repository<PanelSpeeds>,
+  ) {}
+
+  async findAll(): Promise<PPackages[]> {
+    const packages = await this.ppackagesRepository.find();
+    const speeds = await this.panelSpeedsRepository.find();
+    const speedMap = new Map(
+      speeds.map((s) => [s.code.trim(), s.speed ?? 0]),
+    );
+    return packages.map((p) => {
+      const speed = speedMap.get(p.description?.trim() ?? '');
+      if (speed != null && p.quantity != null) {
+        p.total = Number(p.quantity) * Number(speed);
+      }
+      return p;
+    });
+  }
+
+  async findOne(id: number): Promise<PPackages | null> {
+    const pkg = await this.ppackagesRepository.findOne({ where: { id } });
+    if (!pkg) return null;
+
+    const trimmedDesc = pkg.description?.trim();
+    if (trimmedDesc) {
+      const speedRecord = await this.panelSpeedsRepository
+        .createQueryBuilder('ps')
+        .where('RTRIM(ps.code) = :code', { code: trimmedDesc })
+        .getOne();
+
+      if (speedRecord && pkg.quantity != null) {
+        pkg.total = Number(pkg.quantity) * Number(speedRecord.speed ?? 0);
+      }
+    }
+
+    return pkg;
+  }
+
+  async calculateQuantitySpeed(): Promise<{ description: string; code: string; total: number }[]> {
+    return this.ppackagesRepository
+      .createQueryBuilder('p')
+      .innerJoin(PanelSpeeds, 'ps', 'RTRIM(p.description) = RTRIM(ps.code)')
+      .select('p.description', 'description')
+      .addSelect('ps.code', 'code')
+      .addSelect('SUM(p.quantity * ps.speed)', 'total')
+      .groupBy('p.description')
+      .addGroupBy('ps.code')
+      .getRawMany();
+  }
+}

--- a/src/pporderlines2/pporderlines2.module.ts
+++ b/src/pporderlines2/pporderlines2.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Pporderlines2 } from '../entities/entities/Pporderlines2';
+import { PPackages } from '../entities/entities/PPackages';
+import { PanelSpeeds } from '../entities/entities/PanelSpeeds';
+import { Pporderlines2Service } from './pporderlines2.service';
+import { Pporderlines2Resolver } from './pporderlines2.resolver';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Pporderlines2, PPackages, PanelSpeeds])],
+  providers: [Pporderlines2Service, Pporderlines2Resolver],
+})
+export class Pporderlines2Module {}

--- a/src/pporderlines2/pporderlines2.resolver.ts
+++ b/src/pporderlines2/pporderlines2.resolver.ts
@@ -1,0 +1,18 @@
+import { Resolver, Query, Args, Int } from '@nestjs/graphql';
+import { Pporderlines2Service } from './pporderlines2.service';
+import { Pporderlines2 } from '../entities/entities/Pporderlines2';
+
+@Resolver(() => Pporderlines2)
+export class Pporderlines2Resolver {
+  constructor(private readonly pporderlines2Service: Pporderlines2Service) {}
+
+  @Query(() => [Pporderlines2])
+  async pporderlines2(): Promise<Pporderlines2[]> {
+    return this.pporderlines2Service.findAll();
+  }
+
+  @Query(() => Pporderlines2, { nullable: true })
+  async pporderline2(@Args('id', { type: () => Int }) id: number): Promise<Pporderlines2 | null> {
+    return this.pporderlines2Service.findOne(id);
+  }
+}

--- a/src/pporderlines2/pporderlines2.service.ts
+++ b/src/pporderlines2/pporderlines2.service.ts
@@ -1,0 +1,44 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Pporderlines2 } from '../entities/entities/Pporderlines2';
+import { PPackages } from '../entities/entities/PPackages';
+import { PanelSpeeds } from '../entities/entities/PanelSpeeds';
+
+@Injectable()
+export class Pporderlines2Service {
+  constructor(
+    @InjectRepository(Pporderlines2)
+    private readonly pporderlines2Repository: Repository<Pporderlines2>,
+    @InjectRepository(PPackages)
+    private readonly ppackagesRepository: Repository<PPackages>,
+    @InjectRepository(PanelSpeeds)
+    private readonly panelSpeedsRepository: Repository<PanelSpeeds>,
+  ) {}
+
+  async findAll(): Promise<Pporderlines2[]> {
+    const lines = await this.pporderlines2Repository.find();
+    for (const line of lines) {
+      line.packagesTotal = await this.getPackagesTotal(line.tradecode);
+    }
+    return lines;
+  }
+
+  async findOne(id: number): Promise<Pporderlines2 | null> {
+    const line = await this.pporderlines2Repository.findOne({ where: { id } });
+    if (!line) return null;
+    line.packagesTotal = await this.getPackagesTotal(line.tradecode);
+    return line;
+  }
+
+  private async getPackagesTotal(tradecode: string | null): Promise<number | null> {
+    if (!tradecode) return null;
+    const result = await this.ppackagesRepository
+      .createQueryBuilder('p')
+      .innerJoin(PanelSpeeds, 'ps', 'RTRIM(p.description) = RTRIM(ps.code)')
+      .where('p.tradecode = :tradecode', { tradecode })
+      .select('SUM(p.quantity * ps.speed)', 'total')
+      .getRawOne<{ total: string }>();
+    return result?.total != null ? Number(result.total) : null;
+  }
+}


### PR DESCRIPTION
## Summary
- expose `Pporderlines2` via GraphQL
- calculate sum of package production times for each order line
- register `Pporderlines2Module` in the main app module

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685469221560832aa0d271ffa3c0f13b